### PR TITLE
Added pen and eraser devices for Wacom touchscreens

### DIFF
--- a/grox.rb
+++ b/grox.rb
@@ -5,13 +5,16 @@
 #   left, right, normal, inverted: absolute movement
 
 # devices to manipulate
+# If you don't have one of the input devices listed, just leave it blank
 $screen = 'eDP1'
-$touchscreen = 'Atmel Atmel maXTouch Digitizer'
-$touchpad = 'ETPS/2 Elantech Touchpad'
+$touchscreen = 'Wacom HID 5196 Finger'
+$pen = 'Wacom HID 5196 Pen Pen (0xae4d0b0a)'
+$eraser = 'Wacom HID 5196 Pen Eraser (0xae4d0b0a)'
+$touchpad = 'SYNA2B31:00 06CB:CD3E Touchpad'
 $keyboard = 'AT Translated Set 2 keyboard'
 
 # disable keypad and touchpad on all but normal orientation
-$controlKeys = true
+$controlKeys = false
 
 # runs cmd and greps output to find orientation
 $orientationCmd = 'xrandr'
@@ -41,6 +44,14 @@ def orientateCmd(orientation, transform)
                               " --type=float" +
                               " 'Coordinate Transformation Matrix'" +
                               " #{transform}"
+    rotatePen = "xinput --set-prop '#{$pen}'" +
+                              " --type=float" +
+                              " 'Coordinate Transformation Matrix'" +
+                              " #{transform}"
+    rotateEraser = "xinput --set-prop '#{$eraser}'" +
+                              " --type=float" +
+                              " 'Coordinate Transformation Matrix'" +
+                              " #{transform}"
     controlKeys = ""
     if $controlKeys
         setCmd = orientation == 'normal' ? 'xinput --enable ' 
@@ -50,7 +61,9 @@ def orientateCmd(orientation, transform)
 
     return controlKeys +
            rotateScreen + ';' +
-           rotateTouchscreen + ';'
+           rotateTouchscreen + ';' + 
+           rotatePen + ';' + 
+           rotateEraser + ';'
 end
 
 


### PR DESCRIPTION
Without these pen and eraser devices, the pen and eraser are skewed and not transformed. 